### PR TITLE
Fix django templates error when getting static files from Google Cloud Storage bucket

### DIFF
--- a/app/server/settings/prod.py
+++ b/app/server/settings/prod.py
@@ -67,6 +67,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 1500
 # Upload generated static files to Google Cloud Storage bucket
 bucket_name = os.environ.get("GCS_BUCKET_NAME", "")
 STATIC_URL = "https://storage.googleapis.com/" + bucket_name + "/"
+GS_DEFAULT_ACL = "publicRead"
 STORAGES = {
     "default": {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",


### PR DESCRIPTION
`django-storages` by default always generates a signed url for downloading data from cloud storage bucket. That's why it threw an error when trying to get static files for `/admin` route. The solution is to tell `django-storages` that default ACL is "publicRead" (since the static files bucket is public), because we don't need to use a signed url. File upload is not affected by this change (upload worked correctly before and still works).

For more context you can read this [issue on django-storages repo](https://github.com/jschneier/django-storages/issues/941#issuecomment-1063526853) and the part about `GS_DEFAULT_ACL` variable from the [django-storages docs](https://django-storages.readthedocs.io/en/latest/backends/gcloud.html).