### PR TITLE
add /lectures/schedule/timer endpoint

### DIFF
--- a/app/client/components/admin/AdminNavBar.tsx
+++ b/app/client/components/admin/AdminNavBar.tsx
@@ -102,6 +102,10 @@ const navbarSections: AdminNavBarSection[] = [
         linkTitle: "Lectures export (for spreadsheet-scheduler) (CSV)",
         href: reverse("list_csv_lectures"),
       },
+      {
+        linkTitle: "Schedule --> export timer data (JSON)",
+        href: reverse("lectures_schedule_timer"),
+      },
       { linkTitle: "Shirts export (CSV)", href: reverse("export_shirts") },
       {
         linkTitle: "Preferences of registered users (CSV)",

--- a/app/server/conferences/models.py
+++ b/app/server/conferences/models.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 import re
 
 from django.core.exceptions import ValidationError
@@ -170,6 +170,10 @@ class Zosia(models.Model):
     @property
     def end_date(self):
         return self.start_date + timedelta(days=3)
+
+    def start_date_unix_timestamp(self):
+        ZOSIA_TIMEZONE = 1*60*60
+        return datetime(*self.start_date.timetuple()[:3]).timestamp() - ZOSIA_TIMEZONE
 
     def __str__(self):
         return f'Zosia {self.start_date.year}'

--- a/app/server/lectures/urls.py
+++ b/app/server/lectures/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('accept/', views.toggle_accept, name="lectures_toggle_accept"),
     path('schedule/', views.schedule_display, name='lectures_schedule'),
     path('schedule/update/', views.schedule_update, name='lectures_schedule_add'),
+    path('schedule/timer', views.schedule_display_timer, name='lectures_schedule_timer'),
     path('durations/', views.load_durations, name='load_durations')
 ]


### PR DESCRIPTION
Add `/lectures/schedule/timer` API endpoint that returns simplified JSON with timestamped lectures schedule, for use with ZOSIA conference timer for speakers.