### PR TITLE
Add all options table under conference update, emphasize PER DAY in discounts

### DIFF
--- a/app/client/components/register/PriceSummary.tsx
+++ b/app/client/components/register/PriceSummary.tsx
@@ -87,7 +87,8 @@ export const CostSummary = ({
               {isStudent && (
                 <li>
                   Discount <span className="font-bold text-error">PER DAY</span>
-                  : <b>{discountPerDay} PLN</b> <br />
+                  {": "}
+                  <b>{discountPerDay} PLN</b> <br />
                   <span className="text-sm italic">
                     This is your possible discount. The actual discount will be
                     calculated after you save your registration.

--- a/app/client/components/register/PriceSummary.tsx
+++ b/app/client/components/register/PriceSummary.tsx
@@ -86,7 +86,8 @@ export const CostSummary = ({
               </li>
               {isStudent && (
                 <li>
-                  Discount per day: <b>{discountPerDay} PLN</b> <br />
+                  Discount <span className="font-bold text-error">PER DAY</span>
+                  : <b>{discountPerDay} PLN</b> <br />
                   <span className="text-sm italic">
                     This is your possible discount. The actual discount will be
                     calculated after you save your registration.

--- a/app/client/templates/AdminConferencesUpdate.tsx
+++ b/app/client/templates/AdminConferencesUpdate.tsx
@@ -1,11 +1,13 @@
 import { AdminCenteredFormContainer } from "@client/components/admin/layout/AdminCenteredFormContainer";
 import { AdminLayout } from "@client/components/admin/layout/AdminLayout";
+import { showCustomToast } from "@client/components/CustomToast";
 import { BasicDescription } from "@client/components/forms/BasicDescription";
 import { BasicFormField } from "@client/components/forms/BasicFormField";
 import { BasicFormWithCustomFields } from "@client/components/forms/BasicFormWithCustomFields";
 import { BasicWidget } from "@client/components/forms/BasicWidget";
 import { PageTitle } from "@client/components/PageTitle";
 import { getConferenceStayPriceCombinations } from "@client/utils/payment";
+import { Field, Label } from "@headlessui/react";
 import { FieldHandler, templates, useForm } from "@reactivated";
 import React from "react";
 
@@ -44,7 +46,10 @@ export const Template = (props: templates.AdminConferencesUpdate) => {
     }
 
     event.preventDefault();
-    window.alert("Possible stay prices contain a negative total price.");
+    showCustomToast(
+      "error",
+      "Possible stay prices contain a negative total price.",
+    );
   };
 
   const discountFields = new Set([
@@ -54,14 +59,18 @@ export const Template = (props: templates.AdminConferencesUpdate) => {
   ]);
 
   const renderDiscountField = (field: FieldHandler, label: string) => (
-    <div className="mb-4 flex flex-col" key={field.name}>
-      <label className="label inline-block text-wrap text-base font-semibold">
+    <Field
+      className="mb-4 flex flex-col"
+      disabled={field.disabled}
+      key={field.name}
+    >
+      <Label className="label inline-block text-wrap text-base font-semibold">
         {label} discount <span className="font-bold text-error">PER DAY</span>
         {field.widget.required && <span className="mx-1 text-error">*</span>}
-      </label>
+      </Label>
       <BasicWidget field={field} />
       <BasicDescription field={field} />
-    </div>
+    </Field>
   );
 
   return (

--- a/app/client/templates/AdminConferencesUpdate.tsx
+++ b/app/client/templates/AdminConferencesUpdate.tsx
@@ -1,8 +1,12 @@
 import { AdminCenteredFormContainer } from "@client/components/admin/layout/AdminCenteredFormContainer";
 import { AdminLayout } from "@client/components/admin/layout/AdminLayout";
-import { BasicForm } from "@client/components/forms/BasicForm";
+import { BasicDescription } from "@client/components/forms/BasicDescription";
+import { BasicFormField } from "@client/components/forms/BasicFormField";
+import { BasicFormWithCustomFields } from "@client/components/forms/BasicFormWithCustomFields";
+import { BasicWidget } from "@client/components/forms/BasicWidget";
 import { PageTitle } from "@client/components/PageTitle";
-import { templates, useForm } from "@reactivated";
+import { getConferenceStayPriceCombinations } from "@client/utils/payment";
+import { FieldHandler, templates, useForm } from "@reactivated";
 import React from "react";
 
 export const Template = (props: templates.AdminConferencesUpdate) => {
@@ -10,11 +14,129 @@ export const Template = (props: templates.AdminConferencesUpdate) => {
 
   const pageTitle = props.edit_mode ? "Update conference" : "Add conference";
 
+  const asNumber = (value: unknown) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const stayPriceCombinations = getConferenceStayPriceCombinations({
+    priceBase: asNumber(form.values.price_base),
+    priceAccommodation: asNumber(form.values.price_accommodation),
+    priceAccommodationBreakfast: asNumber(
+      form.values.price_accommodation_breakfast,
+    ),
+    priceAccommodationDinner: asNumber(form.values.price_accommodation_dinner),
+    priceWholeDay: asNumber(form.values.price_whole_day),
+    discounts: [
+      asNumber(form.values.first_discount),
+      asNumber(form.values.second_discount),
+      asNumber(form.values.third_discount),
+    ],
+  });
+
+  const hasNegativeStayPrice = stayPriceCombinations.some(
+    ({ total }) => total < 0,
+  );
+
+  const onFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    if (!hasNegativeStayPrice) {
+      return;
+    }
+
+    event.preventDefault();
+    window.alert("Possible stay prices contain a negative total price.");
+  };
+
+  const discountFields = new Set([
+    form.fields.first_discount.name,
+    form.fields.second_discount.name,
+    form.fields.third_discount.name,
+  ]);
+
+  const renderDiscountField = (field: FieldHandler, label: string) => (
+    <div className="mb-4 flex flex-col" key={field.name}>
+      <label className="label inline-block text-wrap text-base font-semibold">
+        {label} discount <span className="font-bold text-error">PER DAY</span>
+        {field.widget.required && <span className="mx-1 text-error">*</span>}
+      </label>
+      <BasicWidget field={field} />
+      <BasicDescription field={field} />
+    </div>
+  );
+
   return (
     <AdminLayout>
       <PageTitle>{pageTitle}</PageTitle>
       <AdminCenteredFormContainer>
-        <BasicForm form={form} submitButtonLabel={pageTitle}></BasicForm>
+        <BasicFormWithCustomFields
+          form={form}
+          submitButtonLabel={pageTitle}
+          onFormSubmit={onFormSubmit}
+        >
+          {form.visibleFields.map((field) => {
+            if (discountFields.has(field.name)) {
+              return null;
+            }
+
+            return (
+              <BasicFormField
+                key={field.name}
+                field={field as unknown as FieldHandler}
+              />
+            );
+          })}
+          {renderDiscountField(
+            form.fields.first_discount as unknown as FieldHandler,
+            "First",
+          )}
+          {renderDiscountField(
+            form.fields.second_discount as unknown as FieldHandler,
+            "Second",
+          )}
+          {renderDiscountField(
+            form.fields.third_discount as unknown as FieldHandler,
+            "Third",
+          )}
+        </BasicFormWithCustomFields>
+        <section className="mt-8 overflow-x-auto">
+          <h2 className="mb-4 text-xl font-bold">Possible stay prices</h2>
+          {hasNegativeStayPrice && (
+            <p className="mb-4 font-semibold text-error">
+              Some possible stay prices are negative. Fix prices or discounts
+              before saving.
+            </p>
+          )}
+          <table className="table table-sm">
+            <thead>
+              <tr>
+                <th>Nights</th>
+                <th>Meals</th>
+                <th>Attendee</th>
+                <th>Total price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stayPriceCombinations.map((combination) => (
+                <tr
+                  key={`${combination.nights}-${combination.meals}-${combination.attendee}`}
+                >
+                  <td>{combination.nights}</td>
+                  <td>{combination.meals}</td>
+                  <td>{combination.attendee}</td>
+                  <td>
+                    <b
+                      className={
+                        combination.total < 0 ? "text-error" : undefined
+                      }
+                    >
+                      {combination.total} PLN
+                    </b>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
       </AdminCenteredFormContainer>
     </AdminLayout>
   );

--- a/app/client/templates/Register.tsx
+++ b/app/client/templates/Register.tsx
@@ -7,6 +7,7 @@ import { BasicFormWithCustomFields } from "@client/components/forms/BasicFormWit
 import { AccomodationFieldGroup } from "@client/components/register/AccomodationFieldGroup";
 import { OrganizationSelector } from "@client/components/register/OrganizationSelector";
 import { CostSummary } from "@client/components/register/PriceSummary";
+import { calculateAccomodationDayCost } from "@client/utils/payment";
 import { reverse, templates, useForm } from "@reactivated";
 import React from "react";
 
@@ -35,41 +36,21 @@ export const Template = (props: templates.Register) => {
     },
   ];
 
-  const calculateAccomodationDayCost = (
-    breakfast: boolean,
-    dinner: boolean,
-    accomodation: boolean,
-  ) => {
-    if (!accomodation && !dinner && !breakfast) {
-      return 0;
-    }
-
-    if (dinner && breakfast) {
-      return props.zosia.price_whole_day;
-    }
-
-    if (dinner && !breakfast) {
-      return props.zosia.price_accommodation_dinner;
-    }
-
-    if (!dinner && breakfast) {
-      return props.zosia.price_accommodation_breakfast;
-    }
-
-    return props.zosia.price_accommodation;
-  };
-
   const calculateDiscountForGroup = (accomodation: boolean) => {
     return accomodation ? props.discount : 0;
   };
 
   const accomodationCostPerGroup = accomodationCheckboxesGroups.map(
     ({ dinner, accomodation, breakfast }) =>
-      calculateAccomodationDayCost(
-        breakfast.value,
-        dinner.value,
-        accomodation.value,
-      ),
+      calculateAccomodationDayCost({
+        breakfast: breakfast.value,
+        dinner: dinner.value,
+        accomodation: accomodation.value,
+        priceAccommodation: props.zosia.price_accommodation,
+        priceAccommodationBreakfast: props.zosia.price_accommodation_breakfast,
+        priceAccommodationDinner: props.zosia.price_accommodation_dinner,
+        priceWholeDay: props.zosia.price_whole_day,
+      }),
   );
 
   const discountPerGroup = accomodationCheckboxesGroups.map(

--- a/app/client/utils/payment.ts
+++ b/app/client/utils/payment.ts
@@ -1,0 +1,114 @@
+export interface StayPriceCombination {
+  nights: number;
+  meals: string;
+  attendee: string;
+  total: number;
+}
+
+interface StayPriceConfig {
+  priceBase: number;
+  priceAccommodation: number;
+  priceAccommodationBreakfast: number;
+  priceAccommodationDinner: number;
+  priceWholeDay: number;
+  discounts: number[];
+}
+
+export interface AccomodationDayCostConfig {
+  breakfast: boolean;
+  dinner: boolean;
+  accomodation: boolean;
+  priceAccommodation: number;
+  priceAccommodationBreakfast: number;
+  priceAccommodationDinner: number;
+  priceWholeDay: number;
+}
+
+const MEAL_OPTIONS = [
+  { label: "No meals", dinner: false, breakfast: false },
+  { label: "Dinner only", dinner: true, breakfast: false },
+  { label: "Breakfast only", dinner: false, breakfast: true },
+  { label: "Breakfast and dinner", dinner: true, breakfast: true },
+];
+
+export const calculateAccomodationDayCost = ({
+  breakfast,
+  dinner,
+  accomodation,
+  priceAccommodation,
+  priceAccommodationBreakfast,
+  priceAccommodationDinner,
+  priceWholeDay,
+}: AccomodationDayCostConfig) => {
+  if (!accomodation && !dinner && !breakfast) {
+    return 0;
+  }
+
+  if (dinner && breakfast) {
+    return priceWholeDay;
+  }
+
+  if (dinner) {
+    return priceAccommodationDinner;
+  }
+
+  if (breakfast) {
+    return priceAccommodationBreakfast;
+  }
+
+  return priceAccommodation;
+};
+
+export const getConferenceStayPriceCombinations = ({
+  priceBase,
+  priceAccommodation,
+  priceAccommodationBreakfast,
+  priceAccommodationDinner,
+  priceWholeDay,
+  discounts,
+}: StayPriceConfig): StayPriceCombination[] => {
+  const combinations: StayPriceCombination[] = [];
+
+  for (let days = 2; days <= 4; days += 1) {
+    const nights = days - 1;
+
+    MEAL_OPTIONS.forEach(({ label, dinner, breakfast }) => {
+      const regularTotal =
+        priceBase +
+        nights *
+          calculateAccomodationDayCost({
+            breakfast,
+            dinner,
+            accomodation: true,
+            priceAccommodation,
+            priceAccommodationBreakfast,
+            priceAccommodationDinner,
+            priceWholeDay,
+          });
+
+      combinations.push({
+        nights,
+        meals: label,
+        attendee: "Regular",
+        total: regularTotal,
+      });
+
+      discounts.forEach((discount, index) => {
+        if (discount === 0) {
+          return;
+        }
+
+        const discountRound = index + 1;
+
+        combinations.push({
+          nights,
+          meals: label,
+          attendee: `Student, discount round ${discountRound}`,
+          total: regularTotal - nights * discount,
+        });
+      });
+    });
+  }
+
+  return combinations;
+};

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1523,9 +1523,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1539,9 +1536,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1557,9 +1551,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1573,9 +1564,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1591,9 +1579,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1607,9 +1592,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1625,9 +1607,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1641,9 +1620,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1659,9 +1635,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,9 +1648,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1693,9 +1663,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1710,9 +1677,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1690,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
We already had two fuckups when someone entered discount amount thinking it was in total, not per day.
That's why I want to:
 - emphasize it by making a red PER DAY
 - add a table to the bottom with preview of the total cost of all possible combinations of stay

Here is how it looks:
<img width="953" height="461" alt="image" src="https://github.com/user-attachments/assets/cab114eb-bd93-4e7a-a6b1-58cfdf8414b5" />

<img width="972" height="1214" alt="image" src="https://github.com/user-attachments/assets/9d5fd802-5bfb-4d30-b1d2-7148a091f51d" />